### PR TITLE
These changes were needed to get this to deploy via dokku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 
 RUN apt-get update && \
-	apt-get install -y gnupg2 wget dnsutils vim telnet && \
+	apt-get install --allow-unauthenticated -y gnupg2 wget dnsutils vim telnet && \
 	echo 'deb http://download.jitsi.org/nightly/deb unstable/' >> /etc/apt/sources.list && \
 	wget -qO - https://download.jitsi.org/nightly/deb/unstable/archive.key | apt-key add - && \
 	apt-get update && \
-	apt-get -y install jitsi-meet && \
+	apt-get --allow-unauthenticated -y install jitsi-meet && \
 	apt-get clean
 
 #ENV PUBLIC_HOSTNAME=192.168.59.103

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm
 
 RUN apt-get update && \
-	apt-get install -y wget dnsutils vim telnet && \
+	apt-get install -y gnupg2 wget dnsutils vim telnet && \
 	echo 'deb http://download.jitsi.org/nightly/deb unstable/' >> /etc/apt/sources.list && \
 	wget -qO - https://download.jitsi.org/nightly/deb/unstable/archive.key | apt-key add - && \
 	apt-get update && \


### PR DESCRIPTION
We tried to deploy this in a dokku instance and got the following errors:

```
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
remote: The command '/bin/sh -c apt-get update && 	apt-get install -y wget dnsutils vim telnet && 	echo 'deb http://download.jitsi.org/nightly/deb unstable/' >> /etc/apt/sources.list && 	wget -qO - https://download.jitsi.org/nightly/deb/unstable/archive.key | apt-key add - && 	apt-get update && 	apt-get -y install jitsi-meet && 	apt-get clean' returned a non-zero code: 255
remote: 
```

```
WARNING: The following packages cannot be authenticated!
  jitsi-archive-keyring jitsi-videobridge jicofo jitsi-meet-prosody jitsi-meet
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
remote: The command '/bin/sh -c apt-get update && 	apt-get install -y gnupg2 wget dnsutils vim telnet && 	echo 'deb http://download.jitsi.org/nightly/deb unstable/' >> /etc/apt/sources.list && 	wget -qO - https://download.jitsi.org/nightly/deb/unstable/archive.key | apt-key add - && 	apt-get update && 	apt-get -y install jitsi-meet && 	apt-get clean' returned a non-zero code: 100
```

so we added the gnupg2 package and the --allow-unauthenticated flag

The deployment completes, but we don't get a working instance - we end up with the following in our logs:

```
2018-04-30T12:43:53.446617650Z app[web.1]: JVB 2018-04-30 12:43:52.562 SEVERE: [25] org.jitsi.meet.ComponentMain.call().278 host-unknown, host:localhost, port:5347
2018-04-30T12:43:53.446655351Z app[web.1]: org.xmpp.component.ComponentException: host-unknown
2018-04-30T12:43:53.446662551Z app[web.1]: 	at org.jivesoftware.whack.ExternalComponent.connect(ExternalComponent.java:219)
2018-04-30T12:43:53.446667852Z app[web.1]: 	at org.jivesoftware.whack.ExternalComponentManager.addComponent(ExternalComponentManager.java:221)
```